### PR TITLE
Update download location for get pip

### DIFF
--- a/Cabot/Dockerfile
+++ b/Cabot/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER Alexander Kushnarev <avkushnarev@gmail.com>
 RUN apt-get update
 RUN apt-get install -y build-essential nodejs libpq-dev python-dev npm git curl libldap2-dev libsasl2-dev iputils-ping
 
-RUN curl -OL https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+RUN curl -OL https://bootstrap.pypa.io/get-pip.py
 RUN python get-pip.py
 
 # Deploy cabot


### PR DESCRIPTION
The old location generated a "You're using an outdated location for the get-pip.py script" error. Now download get-pip from the new location.